### PR TITLE
Fix: Update web scraping logic for Wikipedia bank data

### DIFF
--- a/maiores_bancos_por_capitalizacao.csv
+++ b/maiores_bancos_por_capitalizacao.csv
@@ -1,0 +1,6 @@
+Nome do Banco,Capitalização em GBP,Capitalização em EUR,Capitalização em INR
+JPMorgan Chase,479.94,557.94,49764.28
+Bank of America,246.32,286.35,25540.3
+Industrial and Commercial Bank of China,242.83,282.29,25178.89
+Agricultural Bank of China,186.27,216.54,19313.75
+Bank of China,167.44,194.64,17361.02


### PR DESCRIPTION
- Modified the method for locating the 'By market capitalization' table on the Wikipedia page to be more resilient to HTML structure changes.
- The script now targets the 3rd table with class 'wikitable' and extracts columns based on expected patterns for that specific table.
- Improved data cleaning to remove residual header rows from the parsed DataFrame before attempting numeric conversion.
- Added User-Agent to requests to mimic browser behavior.
- Ensured the script correctly processes and transforms data for the top 5 banks.

## Summary by Sourcery

Improve ETL pipeline resilience by adding browser-like headers, using a more robust table selection strategy, and enhancing data cleaning before extracting the top five banks.

Bug Fixes:
- Handle failures when the expected table cannot be processed and exit with a clear error message

Enhancements:
- Add a User-Agent header to HTTP requests to mimic browser traffic
- Select the "By market capitalization" table as the third .wikitable element instead of relying on a specific span id
- Filter out residual headers, non-bank entries, and repeated header rows from the parsed DataFrame
- Remove redundant debug prints and simplify column renaming logic